### PR TITLE
[ken-schedule-v2] Make aumni logo first and larger; add logos to schedule page

### DIFF
--- a/gatsby/src/components/ConferenceSponsors.js
+++ b/gatsby/src/components/ConferenceSponsors.js
@@ -14,11 +14,15 @@ const Wrapper = styled.div`
   .wrapper {
     border-top: 2px dotted #ccc;
     display: flex;
-    flex-direction: column;
+    flex-direction: column-reverse;
     align-items: center;
   }
   .spacer {
     margin-top: 20px;
+  }
+  a[href*='aumni.fund'] {
+    transform: scale(1.5);
+    display: block;
   }
   @media (min-width: 768px) {
     align-items: center;

--- a/gatsby/src/pages/schedule.js
+++ b/gatsby/src/pages/schedule.js
@@ -3,14 +3,31 @@ import { graphql } from 'gatsby';
 import styled from 'styled-components';
 import Layout from '../components/layout/Layout';
 import SEO from '../components/Seo';
+import Sponsors from '../components/ConferenceSponsors.js';
 
 const PageStyles = styled.div`
-  @media (min-width: 980px) {
-    .padding {
-      padding-top: 40px;
+  @media (max-width: 600px) {
+    .headings {
+      display: block !important;
+      text-align: center;
+    }
+    .sponsors-column {
+      transform-origin: center top !important;
     }
   }
-
+  .headings {
+    display: flex;
+    padding-top: 40px;
+    justify-content: space-between;
+  }
+  h1 {
+    padding: 0 40px 0 0;
+    margin: 22px 0 0 0;
+  }
+  .sponsors-column {
+    transform: scale(0.75);
+    transform-origin: right top;
+  }
   /* hide some confusing session elements */
   .sz-day__title,
   .sz-powered-by,
@@ -100,8 +117,12 @@ export default function Schedule({ data }) {
     <Layout>
       <SEO seo={seo} />
       <PageStyles className="center-content">
-        <div className="padding" />
-        <h1>Conference Schedule: Friday, October 8, 2021</h1>
+        <div className="headings">
+          <h1>Conference Schedule: Friday, October 8, 2021</h1>
+          <div className="sponsors-column">
+            <Sponsors />
+          </div>
+        </div>
         <div id="EmbedWrapper" />
       </PageStyles>
     </Layout>


### PR DESCRIPTION
Longer term, I want to add sort order and tier (premier, gold, silver, bronze). For now, this just uses CSS to make the aumni logo larger.

![image](https://user-images.githubusercontent.com/102264/133959998-956618d2-59b9-4b81-9c74-d7a991161106.png)
