### PR TITLE
Bowser/bring in 2022 sanity data

### DIFF
--- a/gatsby/src/components/ConferenceSponsors.js
+++ b/gatsby/src/components/ConferenceSponsors.js
@@ -53,7 +53,7 @@ const Sponsors = () => {
   `);
   return (
     <Wrapper>
-      <h2>Thank you to our 2021 sponsors!</h2>
+      <h2>Thank you to our 2022 sponsors!</h2>
       <div className="wrapper">
         {data.allSanitySponsors.nodes.map((sponsor, id) => (
           <div className="spacer" key={`sponsor${id}`}>

--- a/gatsby/src/components/layout/Nav.js
+++ b/gatsby/src/components/layout/Nav.js
@@ -103,14 +103,8 @@ const Nav = ({ toggle }) => {
     <NavStyles>
       <div className={!toggle ? 'navDiv Close' : 'navDiv Open'}>
         <ul>
-          {navArray.map((nav, id) => {
-            // FIXME: This is a janky temp fix to change the schedule link text in the nav.
-            // Looks like this can be updated by someone in sanity, then this can be removed
-            nav.link_text =
-              nav.link_text === '2021 Schedule'
-                ? '2022 Schedule'
-                : nav.link_text;
-            return nav.internal_link !== null ? (
+          {navArray.map((nav, id) =>
+            nav.internal_link !== null ? (
               <li key={id}>
                 <StyledLink
                   to={nav.internal_link}
@@ -130,8 +124,8 @@ const Nav = ({ toggle }) => {
                   {nav.link_text}
                 </a>
               </li>
-            );
-          })}
+            )
+          )}
         </ul>
       </div>
     </NavStyles>

--- a/gatsby/src/pages/conference.js
+++ b/gatsby/src/pages/conference.js
@@ -111,7 +111,7 @@ export default function conferencePage({ data }) {
               <a href="/schedule">See full schedule &rsaquo;</a>
             </p>
           </div>
-          <Sponsors />
+          {/* FIXME: uncomment when sponsors are up to date <Sponsors /> */}
         </div>
       </Wrapper>
     </Layout>

--- a/gatsby/src/pages/schedule.js
+++ b/gatsby/src/pages/schedule.js
@@ -119,9 +119,9 @@ export default function Schedule({ data }) {
       <PageStyles className="center-content">
         <div className="headings">
           <h1>Conference Schedule: Friday, September 23, 2022</h1>
-          <div className="sponsors-column">
+          {/* FIXME: uncomment when sponsors are up to date <div className="sponsors-column">
             <Sponsors />
-          </div>
+          </div> */}
         </div>
         <div id="EmbedWrapper" />
       </PageStyles>

--- a/gatsby/src/pages/schedule.js
+++ b/gatsby/src/pages/schedule.js
@@ -97,21 +97,20 @@ const PageStyles = styled.div`
 `;
 
 export default function Schedule({ data }) {
-  // FIXME: uncomment once the 2022 schedule is ready to be pulled in from sessionize
-  // useEffect(() => {
-  //   // load sessionize embed
-  //   const script = document.createElement('script');
-  //   script.src = 'https://sessionize.com/api/v2/bxy86zel/view/GridSmart';
-  //   script.onload = () => window.sessionize.loader();
-  //   // sessionize embed uses document.write, so we need to override it with
-  //   // code that will insert CSS and html into the right place
-  //   document.write = (html) => {
-  //     const div = document.createElement('div');
-  //     div.innerHTML = html;
-  //     document.querySelector('#EmbedWrapper').appendChild(div);
-  //   };
-  //   document.body.appendChild(script);
-  // }, []);
+  useEffect(() => {
+    // load sessionize embed
+    const script = document.createElement('script');
+    script.src = 'https://sessionize.com/api/v2/bxy86zel/view/GridSmart';
+    script.onload = () => window.sessionize.loader();
+    // sessionize embed uses document.write, so we need to override it with
+    // code that will insert CSS and html into the right place
+    document.write = (html) => {
+      const div = document.createElement('div');
+      div.innerHTML = html;
+      document.querySelector('#EmbedWrapper').appendChild(div);
+    };
+    document.body.appendChild(script);
+  }, []);
   const seo = data.allSanitySeo.nodes[0];
 
   return (
@@ -120,14 +119,11 @@ export default function Schedule({ data }) {
       <PageStyles className="center-content">
         <div className="headings">
           <h1>Conference Schedule: Friday, September 23, 2022</h1>
-          {/* FIXME: Commenting out until 2022 details are finalized
           <div className="sponsors-column">
             <Sponsors />
-          </div> */}
+          </div>
         </div>
-        <h3>2022 Schedule TBA.</h3>
-        <p>Please come back later for updates.</p>
-        {/* FIXME <div id="EmbedWrapper" /> */}
+        <div id="EmbedWrapper" />
       </PageStyles>
     </Layout>
   );


### PR DESCRIPTION
Removed the temp fixes for 2021/2022 discrepancies. Pulling in all data from Sanity now. Also updated the Sponsors component title to display the correct year. Screenshot of schedule page after these changes were made is below

![Screen Shot 2022-07-28 at 5 18 43 PM](https://user-images.githubusercontent.com/66637570/181652942-1efba804-c44b-460d-8ae5-67dabea356ec.png)
