### PR TITLE
remove duplicate schedule link on conference page

### DIFF
--- a/gatsby/src/pages/conference.js
+++ b/gatsby/src/pages/conference.js
@@ -98,9 +98,6 @@ export default function conferencePage({ data }) {
             <Link to="/speakers" rel="noreferrer">
               View the speakers
             </Link>
-            <p className="schedule-link">
-              <a href="/schedule">See full schedule &rsaquo;</a>
-            </p>
           </div>
           <Sponsors />
         </div>


### PR DESCRIPTION
The data pulled in from Sanity included a schedule link in addition to one we had hardcoded on the page. Removed the hardcoded one to get rid of the duplication.